### PR TITLE
docs: fix simple typo, logou -> logout

### DIFF
--- a/app/utils/RequestUtil.py
+++ b/app/utils/RequestUtil.py
@@ -35,7 +35,7 @@ def login_user(user):
     session['u_id'] = user
 
 
-# logou user, session pop
+# logout user, session pop
 def logout():
     session.pop('oauth_token', None)
     session.pop('u_id', None)


### PR DESCRIPTION
There is a small typo in app/utils/RequestUtil.py.

Should read `logout` rather than `logou`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md